### PR TITLE
Fix #106

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -52,7 +52,11 @@ LNG="$MODPATH"/Lang/"$LANGS"/"$LANGS"
 #Hiding navbar or not
 cat "$LNG"10.txt
 if $VKSEL; then
-     BH=0.0
+   if [ "$API" -ge 35 ]; then
+      BH=1.0
+   else
+      BH=0.0
+   fi
      SS=true
      HIDE=true
      VAR3=a
@@ -144,7 +148,7 @@ fi
 if [ "$SS" = true ] ; then
      cat "$LNG"9.txt
      if $VKSEL; then
-      if [ "$FH" = 0 ] ; then
+      if [ "$FH" = 0.0 ] ; then
       BH=1.0
       FH=1.0
       else


### PR DESCRIPTION
Fixes https://github.com/DanGLES3/Hide-Navbar/issues/106.

There is also a [small typo](https://github.com/DanGLES3/Hide-Navbar/blob/8b9c204b02c2140e9d60b10233f42d1b1937df75/common/install.sh#L1430-L156) where the value of `$FH` is being checked against `0` rather than `0.0`, causing that change to not actually be applied when selected by the user. This should now be resolved as well (works for me, may need further testing).